### PR TITLE
Enable NSIS logging in the build.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,11 @@ jobs:
       - name: Install constructor
         run: |
           conda info
-          conda install constructor
+          conda install constructor "nsis=*=*log"
       - name: Build the installer
         env:
-          CONDA_CHANNEL_PRIORITY: strict
+          - CONDA_CHANNEL_PRIORITY: strict
+          - NSIS_USING_LOG_BUILD: 1
         run: |
           constructor .
           python pretty_pkg_list.py

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ compatible set of packages and build a `.exe` installer that contains them.
 On Windows, to build the installer, run:
 
 ```
-set CONDA_CHANNEL_PRIORITY=strict
+set "CONDA_CHANNEL_PRIORITY=strict"
 constructor .
 ```
 


### PR DESCRIPTION
This will generate an `install.log` file in the target directory when installing.