### PR TITLE
will build with adapted control, flexible prio

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -4,6 +4,7 @@ company: Delft University of Technology
 installer_type: all
 channels:
   - conda-forge
+  - repa
 specs:
   - altair ==5.5.0
   - arrow ==1.3.0
@@ -20,7 +21,7 @@ specs:
   - colorful ==0.5.6
   - conda ==25.5.1
   - configparser ==7.2.0
-  - control ==0.10.1  # TODO : avoid 0.10.1, see https://gitlab.ewi.tudelft.nl/bhmgerritsen/anaconda-dee-config/-/issues/81
+  - control ==0.10.1c  # TODO : avoid 0.10.1, see https://gitlab.ewi.tudelft.nl/bhmgerritsen/anaconda-dee-config/-/issues/81
   - coolprop ==6.7.0
   - curl ==8.14.1
   - cython ==3.1.2
@@ -50,7 +51,7 @@ specs:
   - mccabe ==0.7.0
   - menuinst ==2.3.0
   - mesa ==3.2.0
-  - miniforge_console_shortcut ==2.0
+  - miniforge_console_shortcut ==2.0 # [win]
   - mkl-service ==2.5.1  # [win]
   - more-itertools ==10.7.0
   - mpmath ==1.3.0


### PR DESCRIPTION
I built a python-control (0.10.1c) to be independent of python version (python-abi3), and numpy >=2.0

Need to build with 

    CONDA_CHANNEL_PRIORITY=flexible constructor .

for this. But I think that is the meaning of flexible vs strict; if strict, the channel order matters.